### PR TITLE
Iterate on KString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+- `serde` support is now optional (still on by default)
+
 ## [1.0.1] - 2021-01-29
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,11 @@ edition = "2018"
 azure-devops = { project = "cobalt-org", pipeline = "kstring" }
 maintenance = { status = "passively-maintained" }
 
+[features]
+default = ["serde"]
+
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -1,6 +1,10 @@
-#![allow(clippy::clone_on_copy, clippy::identity_conversion)]
+#![allow(
+    clippy::clone_on_copy,
+    clippy::identity_conversion,
+    clippy::clone_double_ref
+)]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 type StringCow<'s> = std::borrow::Cow<'s, str>;
 
@@ -25,28 +29,35 @@ fn bench_clone_static(c: &mut Criterion) {
     let mut group = c.benchmark_group("clone static");
     for fixture in FIXTURES {
         let len = fixture.len();
+        group.throughput(Throughput::Bytes(len as u64));
         group.bench_with_input(BenchmarkId::new("str", len), &len, |b, _| {
             let uut = *fixture;
-            b.iter(|| uut)
+            let uut = criterion::black_box(uut);
+            b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let uut = String::from(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("StringCow", len), &len, |b, _| {
             let uut = StringCow::from(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KString", len), &len, |b, _| {
             let uut = kstring::KString::from_static(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KStringCow", len), &len, |b, _| {
             let uut = kstring::KStringCow::from_static(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KStringRef", len), &len, |b, _| {
             let uut = kstring::KStringRef::from_static(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
     }
@@ -58,28 +69,35 @@ fn bench_clone_ref(c: &mut Criterion) {
     for fixture in FIXTURES {
         let len = fixture.len();
         let fixture = String::from(*fixture);
+        group.throughput(Throughput::Bytes(len as u64));
         group.bench_with_input(BenchmarkId::new("str", len), &len, |b, _| {
             let uut = fixture.as_str();
-            b.iter(|| uut)
+            let uut = criterion::black_box(uut);
+            b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let uut = String::from(fixture.as_str());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("StringCow", len), &len, |b, _| {
             let uut = StringCow::from(fixture.as_str());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KString", len), &len, |b, _| {
             let uut = kstring::KString::from_ref(fixture.as_str());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KStringCow", len), &len, |b, _| {
             let uut = kstring::KStringCow::from_ref(fixture.as_str());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KStringRef", len), &len, |b, _| {
             let uut = kstring::KStringRef::from_ref(fixture.as_str());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
     }
@@ -90,24 +108,29 @@ fn bench_clone_owned(c: &mut Criterion) {
     let mut group = c.benchmark_group("clone owned");
     for fixture in FIXTURES {
         let len = fixture.len();
+        group.throughput(Throughput::Bytes(len as u64));
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = String::from(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("StringCow", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = StringCow::from(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KString", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = kstring::KString::from_string(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
         group.bench_with_input(BenchmarkId::new("KStringCow", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = kstring::KStringCow::from_string(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
     }
@@ -118,28 +141,35 @@ fn bench_eq_static(c: &mut Criterion) {
     let mut group = c.benchmark_group("eq static");
     for fixture in FIXTURES {
         let len = fixture.len();
+        group.throughput(Throughput::Bytes(len as u64));
         group.bench_with_input(BenchmarkId::new("str", len), &len, |b, _| {
             let uut = *fixture;
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == *fixture)
         });
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let uut = String::from(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == *fixture)
         });
         group.bench_with_input(BenchmarkId::new("StringCow", len), &len, |b, _| {
             let uut = StringCow::from(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == *fixture)
         });
         group.bench_with_input(BenchmarkId::new("KString", len), &len, |b, _| {
             let uut = kstring::KString::from_static(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == *fixture)
         });
         group.bench_with_input(BenchmarkId::new("KStringCow", len), &len, |b, _| {
             let uut = kstring::KStringCow::from_static(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == *fixture)
         });
         group.bench_with_input(BenchmarkId::new("KStringRef", len), &len, |b, _| {
             let uut = kstring::KStringRef::from_static(*fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == *fixture)
         });
     }
@@ -152,28 +182,35 @@ fn bench_eq_ref(c: &mut Criterion) {
         let len = fixture.len();
         let fixture = String::from(*fixture);
         let fixture = fixture.as_str();
+        group.throughput(Throughput::Bytes(len as u64));
         group.bench_with_input(BenchmarkId::new("str", len), &len, |b, _| {
             let uut = fixture;
+            let uut = criterion::black_box(uut);
             b.iter(|| uut)
         });
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let uut = String::from(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
         group.bench_with_input(BenchmarkId::new("StringCow", len), &len, |b, _| {
             let uut = StringCow::from(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
         group.bench_with_input(BenchmarkId::new("KString", len), &len, |b, _| {
             let uut = kstring::KString::from_ref(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
         group.bench_with_input(BenchmarkId::new("KStringCow", len), &len, |b, _| {
             let uut = kstring::KStringCow::from_ref(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
         group.bench_with_input(BenchmarkId::new("KStringRef", len), &len, |b, _| {
             let uut = kstring::KStringRef::from_ref(fixture);
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
     }
@@ -184,24 +221,29 @@ fn bench_eq_owned(c: &mut Criterion) {
     let mut group = c.benchmark_group("eq owned");
     for fixture in FIXTURES {
         let len = fixture.len();
+        group.throughput(Throughput::Bytes(len as u64));
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = String::from(fixture.clone());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
         group.bench_with_input(BenchmarkId::new("StringCow", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = StringCow::from(fixture.clone());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
         group.bench_with_input(BenchmarkId::new("KString", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = kstring::KString::from_string(fixture.clone());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
         group.bench_with_input(BenchmarkId::new("KStringCow", len), &len, |b, _| {
             let fixture = String::from(*fixture);
             let uut = kstring::KStringCow::from_string(fixture.clone());
+            let uut = criterion::black_box(uut);
             b.iter(|| uut == fixture)
         });
     }

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -255,7 +255,7 @@ impl<'s> Default for KStringCow<'s> {
     }
 }
 
-impl From<KString> for KStringCow<'static> {
+impl<'s> From<KString> for KStringCow<'s> {
     #[inline]
     fn from(other: KString) -> Self {
         let inner = KStringCowInner::Owned(other);
@@ -291,7 +291,7 @@ impl<'s> From<&'s KStringRef<'s>> for KStringCow<'s> {
     }
 }
 
-impl From<StdString> for KStringCow<'static> {
+impl<'s> From<StdString> for KStringCow<'s> {
     #[inline]
     fn from(other: StdString) -> Self {
         Self::from_string(other)
@@ -305,7 +305,7 @@ impl<'s> From<&'s StdString> for KStringCow<'s> {
     }
 }
 
-impl From<BoxedStr> for KStringCow<'static> {
+impl<'s> From<BoxedStr> for KStringCow<'s> {
     #[inline]
     fn from(other: BoxedStr) -> Self {
         // Since the memory is already allocated, don't bother moving it into a FixedString

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -326,6 +326,7 @@ impl<'s> From<&'s str> for KStringCow<'s> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'s> serde::Serialize for KStringCow<'s> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -336,6 +337,7 @@ impl<'s> serde::Serialize for KStringCow<'s> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, 's> serde::Deserialize<'de> for KStringCow<'s> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -16,8 +16,8 @@ pub struct KStringCow<'s> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum KStringCowInner<'s> {
-    Owned(KString),
     Borrowed(&'s str),
+    Owned(KString),
 }
 
 impl<'s> KStringCow<'s> {
@@ -98,32 +98,32 @@ impl<'s> KStringCowInner<'s> {
     #[inline]
     fn as_ref(&self) -> KStringRef<'_> {
         match self {
-            Self::Owned(ref s) => s.as_ref(),
             Self::Borrowed(ref s) => KStringRef::from_ref(s),
+            Self::Owned(ref s) => s.as_ref(),
         }
     }
 
     #[inline]
     fn into_owned(self) -> KString {
         match self {
-            Self::Owned(s) => s,
             Self::Borrowed(s) => KString::from_ref(s),
+            Self::Owned(s) => s,
         }
     }
 
     #[inline]
     fn as_str(&self) -> &str {
         match self {
-            Self::Owned(ref s) => s.as_str(),
             Self::Borrowed(ref s) => s,
+            Self::Owned(ref s) => s.as_str(),
         }
     }
 
     #[inline]
     fn into_boxed_str(self) -> BoxedStr {
         match self {
-            Self::Owned(s) => s.into_boxed_str(),
             Self::Borrowed(s) => BoxedStr::from(s),
+            Self::Owned(s) => s.into_boxed_str(),
         }
     }
 
@@ -131,8 +131,8 @@ impl<'s> KStringCowInner<'s> {
     #[inline]
     fn into_cow_str(self) -> Cow<'s, str> {
         match self {
-            Self::Owned(s) => s.into_cow_str(),
             Self::Borrowed(s) => Cow::Borrowed(s),
+            Self::Owned(s) => s.into_cow_str(),
         }
     }
 }

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -38,7 +38,9 @@ impl<'s> KStringCow<'s> {
     /// Create an owned `KStringCow`.
     #[inline]
     pub fn from_string(other: StdString) -> Self {
-        Self::from_boxed(other.into_boxed_str())
+        Self {
+            inner: KStringCowInner::Owned(KString::from_string(other)),
+        }
     }
 
     /// Create a reference to a borrowed data.
@@ -292,8 +294,7 @@ impl<'s> From<&'s KStringRef<'s>> for KStringCow<'s> {
 impl From<StdString> for KStringCow<'static> {
     #[inline]
     fn from(other: StdString) -> Self {
-        // Since the memory is already allocated, don't bother moving it into a FixedString
-        Self::from_boxed(other.into_boxed_str())
+        Self::from_string(other)
     }
 }
 

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -9,7 +9,7 @@ macro_rules! fixed_string {
 
         impl $name {
             pub(crate) fn new(s: &str) -> Self {
-                assert_eq!(s.as_bytes().len(), $len);
+                debug_assert_eq!(s.as_bytes().len(), $len);
                 let mut array = [0; $len];
                 array.copy_from_slice(&s.as_bytes()[0..$len]);
                 Self { array }

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -235,6 +235,7 @@ impl<'s> From<&'s str> for KStringRef<'s> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'s> serde::Serialize for KStringRef<'s> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -245,6 +246,7 @@ impl<'s> serde::Serialize for KStringRef<'s> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de: 's, 's> serde::Deserialize<'de> for KStringRef<'s> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -44,6 +44,7 @@ impl<'s> KStringRef<'s> {
 
     /// Clone the data into an owned-type.
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_owned(&self) -> KString {
         self.inner.to_owned()
     }
@@ -63,6 +64,7 @@ impl<'s> KStringRef<'s> {
 
 impl<'s> KStringRefInner<'s> {
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     fn to_owned(&self) -> KString {
         match self {
             Self::Borrowed(s) => KString::from_ref(s),

--- a/src/string.rs
+++ b/src/string.rs
@@ -16,7 +16,6 @@ pub struct KString {
 
 #[derive(Clone, Debug)]
 pub(crate) enum KStringInner {
-    Owned(BoxedStr),
     Singleton(&'static str),
     Fixed1(FixedString1),
     Fixed2(FixedString2),
@@ -34,6 +33,7 @@ pub(crate) enum KStringInner {
     Fixed14(FixedString14),
     Fixed15(FixedString15),
     Fixed16(FixedString16),
+    Owned(BoxedStr),
 }
 
 impl KString {
@@ -126,7 +126,6 @@ impl KStringInner {
     #[inline]
     fn as_ref(&self) -> KStringRef<'_> {
         match self {
-            Self::Owned(ref s) => KStringRef::from_ref(s),
             Self::Singleton(ref s) => KStringRef::from_static(s),
             Self::Fixed1(ref s) => KStringRef::from_ref(s.as_str()),
             Self::Fixed2(ref s) => KStringRef::from_ref(s.as_str()),
@@ -144,13 +143,13 @@ impl KStringInner {
             Self::Fixed14(ref s) => KStringRef::from_ref(s.as_str()),
             Self::Fixed15(ref s) => KStringRef::from_ref(s.as_str()),
             Self::Fixed16(ref s) => KStringRef::from_ref(s.as_str()),
+            Self::Owned(ref s) => KStringRef::from_ref(s),
         }
     }
 
     #[inline]
     fn as_str(&self) -> &str {
         match self {
-            Self::Owned(ref s) => &s,
             Self::Singleton(ref s) => s,
             Self::Fixed1(ref s) => s.as_str(),
             Self::Fixed2(ref s) => s.as_str(),
@@ -168,13 +167,13 @@ impl KStringInner {
             Self::Fixed14(ref s) => s.as_str(),
             Self::Fixed15(ref s) => s.as_str(),
             Self::Fixed16(ref s) => s.as_str(),
+            Self::Owned(ref s) => &s,
         }
     }
 
     #[inline]
     fn into_boxed_str(self) -> BoxedStr {
         match self {
-            Self::Owned(s) => s,
             Self::Singleton(s) => BoxedStr::from(s),
             Self::Fixed1(s) => s.to_boxed_str(),
             Self::Fixed2(s) => s.to_boxed_str(),
@@ -192,6 +191,7 @@ impl KStringInner {
             Self::Fixed14(s) => s.to_boxed_str(),
             Self::Fixed15(s) => s.to_boxed_str(),
             Self::Fixed16(s) => s.to_boxed_str(),
+            Self::Owned(s) => s,
         }
     }
 
@@ -199,7 +199,6 @@ impl KStringInner {
     #[inline]
     fn into_cow_str(self) -> Cow<'static, str> {
         match self {
-            Self::Owned(s) => Cow::Owned(s.into()),
             Self::Singleton(s) => Cow::Borrowed(s),
             Self::Fixed1(s) => Cow::Owned(s.to_boxed_str().into()),
             Self::Fixed2(s) => Cow::Owned(s.to_boxed_str().into()),
@@ -217,6 +216,7 @@ impl KStringInner {
             Self::Fixed14(s) => Cow::Owned(s.to_boxed_str().into()),
             Self::Fixed15(s) => Cow::Owned(s.to_boxed_str().into()),
             Self::Fixed16(s) => Cow::Owned(s.to_boxed_str().into()),
+            Self::Owned(s) => Cow::Owned(s.into()),
         }
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -54,7 +54,27 @@ impl KString {
     /// Create an owned `KString`.
     #[inline]
     pub fn from_string(other: StdString) -> Self {
-        Self::from_boxed(other.into_boxed_str())
+        let inner = match other.len() {
+            0 => KStringInner::Singleton(""),
+            1 => KStringInner::Fixed1(FixedString1::new(other.as_str())),
+            2 => KStringInner::Fixed2(FixedString2::new(other.as_str())),
+            3 => KStringInner::Fixed3(FixedString3::new(other.as_str())),
+            4 => KStringInner::Fixed4(FixedString4::new(other.as_str())),
+            5 => KStringInner::Fixed5(FixedString5::new(other.as_str())),
+            6 => KStringInner::Fixed6(FixedString6::new(other.as_str())),
+            7 => KStringInner::Fixed7(FixedString7::new(other.as_str())),
+            8 => KStringInner::Fixed8(FixedString8::new(other.as_str())),
+            9 => KStringInner::Fixed9(FixedString9::new(other.as_str())),
+            10 => KStringInner::Fixed10(FixedString10::new(other.as_str())),
+            11 => KStringInner::Fixed11(FixedString11::new(other.as_str())),
+            12 => KStringInner::Fixed12(FixedString12::new(other.as_str())),
+            13 => KStringInner::Fixed13(FixedString13::new(other.as_str())),
+            14 => KStringInner::Fixed14(FixedString14::new(other.as_str())),
+            15 => KStringInner::Fixed15(FixedString15::new(other.as_str())),
+            16 => KStringInner::Fixed16(FixedString16::new(other.as_str())),
+            _ => KStringInner::Owned(other.into_boxed_str()),
+        };
+        Self { inner }
     }
 
     /// Create an owned `KString` optimally from a reference.
@@ -368,8 +388,7 @@ impl<'s> From<&'s KStringCow<'s>> for KString {
 impl From<StdString> for KString {
     #[inline]
     fn from(other: StdString) -> Self {
-        // Since the memory is already allocated, don't bother moving it into a FixedString
-        Self::from_boxed(other.into_boxed_str())
+        Self::from_string(other)
     }
 }
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -395,6 +395,7 @@ impl From<&'static str> for KString {
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde::Serialize for KString {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -405,6 +406,7 @@ impl serde::Serialize for KString {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for KString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -414,8 +416,10 @@ impl<'de> serde::Deserialize<'de> for KString {
     }
 }
 
+#[cfg(feature = "serde")]
 struct StringVisitor;
 
+#[cfg(feature = "serde")]
 impl<'de> serde::de::Visitor<'de> for StringVisitor {
     type Value = KString;
 


### PR DESCRIPTION
I wanted to verify performance before I spoke about it.  KString is slower than I expected.  I think its just the overhead of `.len()` + `match` but it puts us not that far behind an allocator, which bothers me.  This is the result of that exploration with the only measured (via benches) gain being from `from_string` change.