### PR TITLE
perf: Manually handle variants

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.54.0"  # MSRV
+msrv = "1.59.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
             os: windows-latest
             rust: stable
           - target: x86_64-unknown-linux-gnu
-            os: linux-latest
+            os: ubuntu-latest
             rust: stable
           - target: i686-unknown-linux-gnu
-            os: linux-latest
+            os: ubuntu-latest
             rust: stable
           - target: x86_64-apple-darwin
             os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     - name: No-default features
       run: cargo test --target ${{ matrix.target }} --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.54.0"
+    name: "Check MSRV: 1.59.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -101,7 +101,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.54.0  # MSRV
+        toolchain: 1.59.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v1
@@ -155,7 +155,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.54.0  # MSRV
+        toolchain: 1.59.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -57,9 +57,9 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.54.0  # MSRV
+        - 1.59.0  # MSRV
         - stable
-    continue-on-error: ${{ matrix.rust != '1.54.0' }}  # MSRV
+    continue-on-error: ${{ matrix.rust != '1.59.0' }}  # MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -78,12 +78,6 @@ impl<const C: usize> StackString<C> {
             self.len = new_len as u8;
         }
     }
-
-    #[inline]
-    #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_boxed_str(&self) -> Box<str> {
-        Box::from(self.as_str())
-    }
 }
 
 impl<const C: usize> Default for StackString<C> {


### PR DESCRIPTION
Failed attempts
- Switching the tags' value: no effect
- Explicitly making owned clone out-of-line: no effect