### PR TITLE
feat: Offer a safe-only version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01c09fd63b5136fba41aa625c7b3254f0aa0a435ff6ec4b2c9a28d496c83c88"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +289,7 @@ name = "kstring"
 version = "1.0.6"
 dependencies = [
  "criterion",
+ "document-features",
  "proptest",
  "serde",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,14 @@ pre-release-replacements = [
 ]
 
 [features]
-default = ["serde"]
+default = ["unsafe", "serde"]
 
 ## O(1) clone support
 arc = []
 ## Inline (stack) strings use the full width of `KString`s
 max_inline = []
+## Allow unsafe code
+unsafe = []
 
 unstable_bench_subset = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ include = [
   "examples/**/*"
 ]
 
+
+[package.metadata.docs.rs]
+all-features = true
+
 [package.metadata.release]
 pre-release-replacements = [
   {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
@@ -29,13 +33,21 @@ pre-release-replacements = [
 
 [features]
 default = ["serde"]
+
+## O(1) clone support
 arc = []
+## Inline (stack) strings use the full width of `KString`s
 max_inline = []
+
 unstable_bench_subset = []
 
 [dependencies]
-serde = { version = "1.0", optional = true }
 static_assertions = "1.1.0"
+
+## `serde` compatibility
+serde = { version = "1.0", optional = true }
+
+document-features = { version = "0.2", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pre-release-replacements = [
 default = ["serde"]
 arc = []
 max_inline = []
-bench_subset_unstable = []
+unstable_bench_subset = []
 
 [dependencies]
 serde = { version = "1.0", optional = true }

--- a/benches/access.rs
+++ b/benches/access.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 
 type StringCow<'s> = std::borrow::Cow<'s, str>;
 
-#[cfg(not(feature = "bench_subset_unstable"))]
+#[cfg(not(feature = "unstable_bench_subset"))]
 pub static FIXTURES: &[&str] = &[
     "",
     "0",
@@ -26,7 +26,7 @@ pub static FIXTURES: &[&str] = &[
     "01234567890123456789012345678901234567890123456789012345678901234567890123456789",
 ];
 
-#[cfg(feature = "bench_subset_unstable")]
+#[cfg(feature = "unstable_bench_subset")]
 pub static FIXTURES: &[&str] = &[
     "0123456789",
     "01234567890123456789012345678901234567890123456789012345678901234567890123456789",
@@ -76,7 +76,7 @@ fn bench_access(c: &mut Criterion) {
                 b.iter(|| uut.is_empty())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringCow::from_static", len),
             &len,
@@ -86,7 +86,7 @@ fn bench_access(c: &mut Criterion) {
                 b.iter(|| uut.is_empty())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringCow::from_ref", len),
             &len,
@@ -96,7 +96,7 @@ fn bench_access(c: &mut Criterion) {
                 b.iter(|| uut.is_empty())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringCow::from_string", len),
             &len,
@@ -106,7 +106,7 @@ fn bench_access(c: &mut Criterion) {
                 b.iter(|| uut.is_empty())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringRef::from_static", len),
             &len,
@@ -116,7 +116,7 @@ fn bench_access(c: &mut Criterion) {
                 b.iter(|| uut.is_empty())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringRef::from_ref", len),
             &len,

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 
 type StringCow<'s> = std::borrow::Cow<'s, str>;
 
-#[cfg(not(feature = "bench_subset_unstable"))]
+#[cfg(not(feature = "unstable_bench_subset"))]
 pub static FIXTURES: &[&str] = &[
     // Empty handling
     "",
@@ -27,7 +27,7 @@ pub static FIXTURES: &[&str] = &[
     "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
 ];
 
-#[cfg(feature = "bench_subset_unstable")]
+#[cfg(feature = "unstable_bench_subset")]
 pub static FIXTURES: &[&str] = &[
     "0123456789",
     "01234567890123456789012345678901234567890123456789012345678901234567890123456789",
@@ -78,7 +78,7 @@ fn bench_clone(c: &mut Criterion) {
                 b.iter(|| uut.clone())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringCow::from_static", len),
             &len,
@@ -88,7 +88,7 @@ fn bench_clone(c: &mut Criterion) {
                 b.iter(|| uut.clone())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringCow::from_ref", len),
             &len,
@@ -99,7 +99,7 @@ fn bench_clone(c: &mut Criterion) {
                 b.iter(|| uut.clone())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringCow::from_string", len),
             &len,
@@ -110,7 +110,7 @@ fn bench_clone(c: &mut Criterion) {
                 b.iter(|| uut.clone())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringRef::from_static", len),
             &len,
@@ -120,7 +120,7 @@ fn bench_clone(c: &mut Criterion) {
                 b.iter(|| uut.clone())
             },
         );
-        #[cfg(not(feature = "bench_subset_unstable"))]
+        #[cfg(not(feature = "unstable_bench_subset"))]
         group.bench_with_input(
             BenchmarkId::new("KStringRef::from_ref", len),
             &len,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! # Feature Flags
 //!
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
+#![cfg_attr(feature = "safe", forbid(unsafe_code))]
 
 mod stack;
 mod string;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,10 @@
 //!   references (`KStringRef`), and lifetime abstractions (`KStringCow`) to avoid
 //!   allocating for struct field names.
 //! - Use `Box<str>` rather than `String` to use less memory.
+//!
+//! # Feature Flags
+//!
+#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 
 mod stack;
 mod string;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 pub(crate) type Len = u8;
 
+/// Fixed-size stack-allocated string
 #[derive(Copy, Clone)]
 pub struct StackString<const CAPACITY: usize> {
     len: Len,


### PR DESCRIPTION
The problem with this is that each crate has to opt-out of unsafe if you
want everything to be unsafe.  I would have prefered a `safe` feature
flag and that the top-level application would then choose whether it
should be set or not but that doesn't work if we expose `unsafe`
functions in our API; a feature flag shouldn't remove parts of the API.