### PR TITLE
feat!: Allow configuring the backend

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -10,9 +10,9 @@ fn main() {
         .unwrap();
     #[allow(clippy::redundant_closure)] // Needed for consistent type
     let method = match method.as_str() {
-        "from_ref" => |s| kstring::KString::<kstring::backend::DefaultStr>::from_ref(s),
+        "from_ref" => |s| kstring::KString::<kstring::backend::BoxedStr>::from_ref(s),
         "from_string" => {
-            |s| kstring::KString::<kstring::backend::DefaultStr>::from_string(String::from(s))
+            |s| kstring::KString::<kstring::backend::BoxedStr>::from_string(String::from(s))
         }
         _ => panic!("{:?} unsupported, try `from_ref`, `from_string`", method),
     };

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -10,10 +10,8 @@ fn main() {
         .unwrap();
     #[allow(clippy::redundant_closure)] // Needed for consistent type
     let method = match method.as_str() {
-        "from_ref" => |s| kstring::KString::<kstring::backend::BoxedStr>::from_ref(s),
-        "from_string" => {
-            |s| kstring::KString::<kstring::backend::BoxedStr>::from_string(String::from(s))
-        }
+        "from_ref" => |s| kstring::KString::from_ref(s),
+        "from_string" => |s| kstring::KString::from_string(String::from(s)),
         _ => panic!("{:?} unsupported, try `from_ref`, `from_string`", method),
     };
     (0..count).map(|_| method(&sample)).last();

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -10,8 +10,10 @@ fn main() {
         .unwrap();
     #[allow(clippy::redundant_closure)] // Needed for consistent type
     let method = match method.as_str() {
-        "from_ref" => |s| kstring::KString::from_ref(s),
-        "from_string" => |s| kstring::KString::from_string(String::from(s)),
+        "from_ref" => |s| kstring::KString::<kstring::backend::DefaultStr>::from_ref(s),
+        "from_string" => {
+            |s| kstring::KString::<kstring::backend::DefaultStr>::from_string(String::from(s))
+        }
         _ => panic!("{:?} unsupported, try `from_ref`, `from_string`", method),
     };
     (0..count).map(|_| method(&sample)).last();

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "arc")]
-pub type DefaultStr = crate::backend::ArcStr;
+pub(crate) type DefaultStr = crate::backend::ArcStr;
 #[cfg(not(feature = "arc"))]
-pub type DefaultStr = crate::backend::BoxedStr;
+pub(crate) type DefaultStr = crate::backend::BoxedStr;
 
 pub type BoxedStr = Box<str>;
 static_assertions::assert_eq_size!(DefaultStr, BoxedStr);

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,93 @@
+#[cfg(feature = "arc")]
+pub type DefaultStr = crate::backend::ArcStr;
+#[cfg(not(feature = "arc"))]
+pub type DefaultStr = crate::backend::BoxedStr;
+
+pub type BoxedStr = Box<str>;
+static_assertions::assert_eq_size!(DefaultStr, BoxedStr);
+
+pub type ArcStr = std::sync::Arc<str>;
+static_assertions::assert_eq_size!(DefaultStr, ArcStr);
+
+pub type RcStr = std::rc::Rc<str>;
+static_assertions::assert_eq_size!(DefaultStr, RcStr);
+
+pub trait StorageBackend: std::fmt::Debug + Clone + private::Sealed {
+    fn from_str(other: &str) -> Self;
+    fn from_string(other: String) -> Self;
+    fn from_boxed_str(other: BoxedStr) -> Self;
+    fn as_str(&self) -> &str;
+}
+
+impl StorageBackend for BoxedStr {
+    #[inline]
+    fn from_str(other: &str) -> Self {
+        other.into()
+    }
+
+    #[inline]
+    fn from_string(other: String) -> Self {
+        other.into_boxed_str()
+    }
+
+    #[inline]
+    fn from_boxed_str(other: BoxedStr) -> Self {
+        other
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
+impl StorageBackend for ArcStr {
+    #[inline]
+    fn from_str(other: &str) -> Self {
+        other.into()
+    }
+
+    #[inline]
+    fn from_string(other: String) -> Self {
+        other.into_boxed_str().into()
+    }
+
+    #[inline]
+    fn from_boxed_str(other: BoxedStr) -> Self {
+        other.into()
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
+impl StorageBackend for RcStr {
+    #[inline]
+    fn from_str(other: &str) -> Self {
+        other.into()
+    }
+
+    #[inline]
+    fn from_string(other: String) -> Self {
+        other.into_boxed_str().into()
+    }
+
+    #[inline]
+    fn from_boxed_str(other: BoxedStr) -> Self {
+        other.into()
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
+pub(crate) mod private {
+    pub trait Sealed {}
+    impl Sealed for super::BoxedStr {}
+    impl Sealed for super::ArcStr {}
+    impl Sealed for super::RcStr {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ mod string;
 mod string_cow;
 mod string_ref;
 
+pub mod backend;
+
 pub use stack::StackString;
 pub use string::*;
 pub use string_cow::*;
@@ -45,11 +47,11 @@ mod test {
         );
         println!(
             "Box<str>: {}",
-            std::mem::size_of::<crate::string::OwnedStr>()
+            std::mem::size_of::<crate::backend::DefaultStr>()
         );
         println!(
             "Box<Box<str>>: {}",
-            std::mem::size_of::<Box<crate::string::OwnedStr>>()
+            std::mem::size_of::<Box<crate::backend::DefaultStr>>()
         );
         println!("str: {}", std::mem::size_of::<&'static str>());
         println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,21 @@
 //! Key String: Optimized for map keys.
 //!
+//! # Examples
+//!
+//! String creation
+//! ```rust
+//! // Explicit
+//! let literal = kstring::KString::from_static("literal");
+//! // Implicit
+//! let literal = kstring::KString::from("literal");
+//!
+//! // Explicit
+//! let inline = kstring::KString::try_inline("stack").unwrap();
+//! let inline = kstring::KString::from_ref("stack");
+//!
+//! let formatted: kstring::KStringCow = format!("Hello {} and {}", literal, inline).into();
+//! ```
+//!
 //! # Background
 //!
 //! Considerations:
@@ -12,8 +28,8 @@
 //!
 //! Ramifications:
 //! - Inline small strings rather than going to the heap.
-//! - Preserve `&'static str` across strings (`KString`),
-//!   references (`KStringRef`), and lifetime abstractions (`KStringCow`) to avoid
+//! - Preserve `&'static str` across strings ([`KString`]),
+//!   references ([`KStringRef`]), and lifetime abstractions ([`KStringCow`]) to avoid
 //!   allocating for struct field names.
 //! - Use `Box<str>` rather than `String` to use less memory.
 //!

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,22 +1,25 @@
 use std::{borrow::Cow, fmt};
 
 use crate::stack::StackString;
-use crate::KStringCow;
+use crate::KStringCowBase;
 use crate::KStringRef;
 
 pub(crate) type StdString = std::string::String;
 
 /// A UTF-8 encoded, immutable string.
+pub type KString = KStringBase<crate::backend::DefaultStr>;
+
+/// A UTF-8 encoded, immutable string.
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct KString<B = crate::backend::DefaultStr> {
+pub struct KStringBase<B> {
     inner: KStringInner<B>,
 }
 
-impl<B> KString<B> {
-    pub const EMPTY: Self = KString::from_static("");
+impl<B> KStringBase<B> {
+    pub const EMPTY: Self = KStringBase::from_static("");
 
-    /// Create a new empty `KString`.
+    /// Create a new empty `KStringBase`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
@@ -40,8 +43,8 @@ impl<B> KString<B> {
     }
 }
 
-impl<B: crate::backend::StorageBackend> KString<B> {
-    /// Create an owned `KString`.
+impl<B: crate::backend::StorageBackend> KStringBase<B> {
+    /// Create an owned `KStringBase`.
     #[inline]
     #[must_use]
     pub fn from_boxed(other: crate::backend::BoxedStr) -> Self {
@@ -50,7 +53,7 @@ impl<B: crate::backend::StorageBackend> KString<B> {
         }
     }
 
-    /// Create an owned `KString`.
+    /// Create an owned `KStringBase`.
     #[inline]
     #[must_use]
     pub fn from_string(other: StdString) -> Self {
@@ -59,7 +62,7 @@ impl<B: crate::backend::StorageBackend> KString<B> {
         }
     }
 
-    /// Create an owned `KString` optimally from a reference.
+    /// Create an owned `KStringBase` optimally from a reference.
     #[inline]
     #[must_use]
     pub fn from_ref(other: &str) -> Self {
@@ -68,14 +71,14 @@ impl<B: crate::backend::StorageBackend> KString<B> {
         }
     }
 
-    /// Get a reference to the `KString`.
+    /// Get a reference to the `KStringBase`.
     #[inline]
     #[must_use]
     pub fn as_ref(&self) -> KStringRef<'_> {
         self.inner.as_ref()
     }
 
-    /// Extracts a string slice containing the entire `KString`.
+    /// Extracts a string slice containing the entire `KStringBase`.
     #[inline]
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -104,7 +107,7 @@ impl<B: crate::backend::StorageBackend> KString<B> {
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::ops::Deref for KString<B> {
+impl<B: crate::backend::StorageBackend> std::ops::Deref for KStringBase<B> {
     type Target = str;
 
     #[inline]
@@ -113,177 +116,177 @@ impl<B: crate::backend::StorageBackend> std::ops::Deref for KString<B> {
     }
 }
 
-impl<B: crate::backend::StorageBackend> Eq for KString<B> {}
+impl<B: crate::backend::StorageBackend> Eq for KStringBase<B> {}
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<KString<B>> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<KStringBase<B>> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<str> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<str> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         PartialEq::eq(self.as_str(), other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<&'s str> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<&'s str> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
         PartialEq::eq(self.as_str(), *other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<String> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<String> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &StdString) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl<B: crate::backend::StorageBackend> Ord for KString<B> {
+impl<B: crate::backend::StorageBackend> Ord for KStringBase<B> {
     #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
-impl<B: crate::backend::StorageBackend> PartialOrd for KString<B> {
+impl<B: crate::backend::StorageBackend> PartialOrd for KStringBase<B> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.as_str().partial_cmp(other.as_str())
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::hash::Hash for KString<B> {
+impl<B: crate::backend::StorageBackend> std::hash::Hash for KStringBase<B> {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
     }
 }
 
-impl<B: crate::backend::StorageBackend> fmt::Debug for KString<B> {
+impl<B: crate::backend::StorageBackend> fmt::Debug for KStringBase<B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)
     }
 }
 
-impl<B: crate::backend::StorageBackend> fmt::Display for KString<B> {
+impl<B: crate::backend::StorageBackend> fmt::Display for KStringBase<B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<str> for KString<B> {
+impl<B: crate::backend::StorageBackend> AsRef<str> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<[u8]> for KString<B> {
+impl<B: crate::backend::StorageBackend> AsRef<[u8]> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<std::ffi::OsStr> for KString<B> {
+impl<B: crate::backend::StorageBackend> AsRef<std::ffi::OsStr> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &std::ffi::OsStr {
         (&**self).as_ref()
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<std::path::Path> for KString<B> {
+impl<B: crate::backend::StorageBackend> AsRef<std::path::Path> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &std::path::Path {
         std::path::Path::new(self)
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::borrow::Borrow<str> for KString<B> {
+impl<B: crate::backend::StorageBackend> std::borrow::Borrow<str> for KStringBase<B> {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<B: crate::backend::StorageBackend> Default for KString<B> {
+impl<B: crate::backend::StorageBackend> Default for KStringBase<B> {
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<KStringRef<'s>> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> From<KStringRef<'s>> for KStringBase<B> {
     #[inline]
     fn from(other: KStringRef<'s>) -> Self {
         other.to_owned()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringRef<'s>> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> From<&'s KStringRef<'s>> for KStringBase<B> {
     #[inline]
     fn from(other: &'s KStringRef<'s>) -> Self {
         other.to_owned()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<KStringCow<'s, B>> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> From<KStringCowBase<'s, B>> for KStringBase<B> {
     #[inline]
-    fn from(other: KStringCow<'s, B>) -> Self {
+    fn from(other: KStringCowBase<'s, B>) -> Self {
         other.into_owned()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringCow<'s, B>> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> From<&'s KStringCowBase<'s, B>> for KStringBase<B> {
     #[inline]
-    fn from(other: &'s KStringCow<'s, B>) -> Self {
+    fn from(other: &'s KStringCowBase<'s, B>) -> Self {
         other.clone().into_owned()
     }
 }
 
-impl<B: crate::backend::StorageBackend> From<StdString> for KString<B> {
+impl<B: crate::backend::StorageBackend> From<StdString> for KStringBase<B> {
     #[inline]
     fn from(other: StdString) -> Self {
         Self::from_string(other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s StdString> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> From<&'s StdString> for KStringBase<B> {
     #[inline]
     fn from(other: &'s StdString) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl<B: crate::backend::StorageBackend> From<crate::backend::BoxedStr> for KString<B> {
+impl<B: crate::backend::StorageBackend> From<crate::backend::BoxedStr> for KStringBase<B> {
     #[inline]
     fn from(other: crate::backend::BoxedStr) -> Self {
         Self::from_boxed(other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s crate::backend::BoxedStr> for KString<B> {
+impl<'s, B: crate::backend::StorageBackend> From<&'s crate::backend::BoxedStr> for KStringBase<B> {
     #[inline]
     fn from(other: &'s crate::backend::BoxedStr) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl<B: crate::backend::StorageBackend> From<&'static str> for KString<B> {
+impl<B: crate::backend::StorageBackend> From<&'static str> for KStringBase<B> {
     #[inline]
     fn from(other: &'static str) -> Self {
         Self::from_static(other)
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::str::FromStr for KString<B> {
+impl<B: crate::backend::StorageBackend> std::str::FromStr for KStringBase<B> {
     type Err = std::convert::Infallible;
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -292,7 +295,7 @@ impl<B: crate::backend::StorageBackend> std::str::FromStr for KString<B> {
 }
 
 #[cfg(feature = "serde")]
-impl<B: crate::backend::StorageBackend> serde::Serialize for KString<B> {
+impl<B: crate::backend::StorageBackend> serde::Serialize for KStringBase<B> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -303,7 +306,7 @@ impl<B: crate::backend::StorageBackend> serde::Serialize for KString<B> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, B: crate::backend::StorageBackend> serde::Deserialize<'de> for KString<B> {
+impl<'de, B: crate::backend::StorageBackend> serde::Deserialize<'de> for KStringBase<B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -317,7 +320,7 @@ struct StringVisitor<B>(std::marker::PhantomData<B>);
 
 #[cfg(feature = "serde")]
 impl<'de, B: crate::backend::StorageBackend> serde::de::Visitor<'de> for StringVisitor<B> {
-    type Value = KString<B>;
+    type Value = KStringBase<B>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("a string")

--- a/src/string.rs
+++ b/src/string.rs
@@ -43,7 +43,7 @@ impl<B> KStringBase<B> {
     }
 }
 
-impl<B: crate::backend::StorageBackend> KStringBase<B> {
+impl<B: crate::backend::HeapStr> KStringBase<B> {
     /// Create an owned `KStringBase`.
     #[inline]
     #[must_use]
@@ -107,7 +107,7 @@ impl<B: crate::backend::StorageBackend> KStringBase<B> {
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::ops::Deref for KStringBase<B> {
+impl<B: crate::backend::HeapStr> std::ops::Deref for KStringBase<B> {
     type Target = str;
 
     #[inline]
@@ -116,177 +116,177 @@ impl<B: crate::backend::StorageBackend> std::ops::Deref for KStringBase<B> {
     }
 }
 
-impl<B: crate::backend::StorageBackend> Eq for KStringBase<B> {}
+impl<B: crate::backend::HeapStr> Eq for KStringBase<B> {}
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<KStringBase<B>> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> PartialEq<KStringBase<B>> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<str> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> PartialEq<str> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         PartialEq::eq(self.as_str(), other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<&'s str> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> PartialEq<&'s str> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
         PartialEq::eq(self.as_str(), *other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<String> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> PartialEq<String> for KStringBase<B> {
     #[inline]
     fn eq(&self, other: &StdString) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl<B: crate::backend::StorageBackend> Ord for KStringBase<B> {
+impl<B: crate::backend::HeapStr> Ord for KStringBase<B> {
     #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
-impl<B: crate::backend::StorageBackend> PartialOrd for KStringBase<B> {
+impl<B: crate::backend::HeapStr> PartialOrd for KStringBase<B> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.as_str().partial_cmp(other.as_str())
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::hash::Hash for KStringBase<B> {
+impl<B: crate::backend::HeapStr> std::hash::Hash for KStringBase<B> {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
     }
 }
 
-impl<B: crate::backend::StorageBackend> fmt::Debug for KStringBase<B> {
+impl<B: crate::backend::HeapStr> fmt::Debug for KStringBase<B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)
     }
 }
 
-impl<B: crate::backend::StorageBackend> fmt::Display for KStringBase<B> {
+impl<B: crate::backend::HeapStr> fmt::Display for KStringBase<B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<str> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> AsRef<str> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<[u8]> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> AsRef<[u8]> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<std::ffi::OsStr> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> AsRef<std::ffi::OsStr> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &std::ffi::OsStr {
         (&**self).as_ref()
     }
 }
 
-impl<B: crate::backend::StorageBackend> AsRef<std::path::Path> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> AsRef<std::path::Path> for KStringBase<B> {
     #[inline]
     fn as_ref(&self) -> &std::path::Path {
         std::path::Path::new(self)
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::borrow::Borrow<str> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> std::borrow::Borrow<str> for KStringBase<B> {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<B: crate::backend::StorageBackend> Default for KStringBase<B> {
+impl<B: crate::backend::HeapStr> Default for KStringBase<B> {
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<KStringRef<'s>> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> From<KStringRef<'s>> for KStringBase<B> {
     #[inline]
     fn from(other: KStringRef<'s>) -> Self {
         other.to_owned()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringRef<'s>> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s KStringRef<'s>> for KStringBase<B> {
     #[inline]
     fn from(other: &'s KStringRef<'s>) -> Self {
         other.to_owned()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<KStringCowBase<'s, B>> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> From<KStringCowBase<'s, B>> for KStringBase<B> {
     #[inline]
     fn from(other: KStringCowBase<'s, B>) -> Self {
         other.into_owned()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringCowBase<'s, B>> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s KStringCowBase<'s, B>> for KStringBase<B> {
     #[inline]
     fn from(other: &'s KStringCowBase<'s, B>) -> Self {
         other.clone().into_owned()
     }
 }
 
-impl<B: crate::backend::StorageBackend> From<StdString> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> From<StdString> for KStringBase<B> {
     #[inline]
     fn from(other: StdString) -> Self {
         Self::from_string(other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s StdString> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s StdString> for KStringBase<B> {
     #[inline]
     fn from(other: &'s StdString) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl<B: crate::backend::StorageBackend> From<crate::backend::BoxedStr> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> From<crate::backend::BoxedStr> for KStringBase<B> {
     #[inline]
     fn from(other: crate::backend::BoxedStr) -> Self {
         Self::from_boxed(other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s crate::backend::BoxedStr> for KStringBase<B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s crate::backend::BoxedStr> for KStringBase<B> {
     #[inline]
     fn from(other: &'s crate::backend::BoxedStr) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl<B: crate::backend::StorageBackend> From<&'static str> for KStringBase<B> {
+impl<B: crate::backend::HeapStr> From<&'static str> for KStringBase<B> {
     #[inline]
     fn from(other: &'static str) -> Self {
         Self::from_static(other)
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::str::FromStr for KStringBase<B> {
+impl<B: crate::backend::HeapStr> std::str::FromStr for KStringBase<B> {
     type Err = std::convert::Infallible;
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -295,7 +295,7 @@ impl<B: crate::backend::StorageBackend> std::str::FromStr for KStringBase<B> {
 }
 
 #[cfg(feature = "serde")]
-impl<B: crate::backend::StorageBackend> serde::Serialize for KStringBase<B> {
+impl<B: crate::backend::HeapStr> serde::Serialize for KStringBase<B> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -306,7 +306,7 @@ impl<B: crate::backend::StorageBackend> serde::Serialize for KStringBase<B> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, B: crate::backend::StorageBackend> serde::Deserialize<'de> for KStringBase<B> {
+impl<'de, B: crate::backend::HeapStr> serde::Deserialize<'de> for KStringBase<B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -319,7 +319,7 @@ impl<'de, B: crate::backend::StorageBackend> serde::Deserialize<'de> for KString
 struct StringVisitor<B>(std::marker::PhantomData<B>);
 
 #[cfg(feature = "serde")]
-impl<'de, B: crate::backend::StorageBackend> serde::de::Visitor<'de> for StringVisitor<B> {
+impl<'de, B: crate::backend::HeapStr> serde::de::Visitor<'de> for StringVisitor<B> {
     type Value = KStringBase<B>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -392,7 +392,7 @@ mod inner {
         }
     }
 
-    impl<B: crate::backend::StorageBackend> KStringInner<B> {
+    impl<B: crate::backend::HeapStr> KStringInner<B> {
         #[inline]
         pub(super) fn from_boxed(other: BoxedStr) -> Self {
             #[allow(clippy::useless_conversion)]
@@ -465,7 +465,7 @@ mod inner {
     //
     // My only guess is that the `clone()` calls we delegate to are just that much bigger than
     // `as_str()` that, when combined with a jump table, is blowing the icache, slowing things down.
-    impl<B: crate::backend::StorageBackend> Clone for KStringInner<B> {
+    impl<B: crate::backend::HeapStr> Clone for KStringInner<B> {
         fn clone(&self) -> Self {
             match self {
                 Self::Singleton(s) => Self::Singleton(s),
@@ -533,7 +533,7 @@ mod inner {
         }
     }
 
-    impl<B: crate::backend::StorageBackend> KStringInner<B> {
+    impl<B: crate::backend::HeapStr> KStringInner<B> {
         #[inline]
         pub(super) fn from_boxed(other: crate::backend::BoxedStr) -> Self {
             #[allow(clippy::useless_conversion)]
@@ -774,7 +774,7 @@ mod inner {
         }
     }
 
-    impl<B: crate::backend::StorageBackend> std::fmt::Debug for OwnedVariant<B> {
+    impl<B: crate::backend::HeapStr> std::fmt::Debug for OwnedVariant<B> {
         #[inline]
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             self.payload.fmt(f)

--- a/src/string.rs
+++ b/src/string.rs
@@ -5,33 +5,46 @@ use crate::KStringCow;
 use crate::KStringRef;
 
 pub(crate) type StdString = std::string::String;
-type BoxedStr = Box<str>;
-#[cfg(feature = "arc")]
-pub(crate) type OwnedStr = std::sync::Arc<str>;
-#[cfg(not(feature = "arc"))]
-pub(crate) type OwnedStr = Box<str>;
 
 /// A UTF-8 encoded, immutable string.
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct KString {
-    inner: KStringInner,
+pub struct KString<B = crate::backend::DefaultStr> {
+    inner: KStringInner<B>,
 }
 
-impl KString {
+impl<B> KString<B> {
     pub const EMPTY: Self = KString::from_static("");
 
     /// Create a new empty `KString`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        Default::default()
+        Self::EMPTY
     }
 
+    /// Create a reference to a `'static` data.
+    #[inline]
+    #[must_use]
+    pub const fn from_static(other: &'static str) -> Self {
+        Self {
+            inner: KStringInner::from_static(other),
+        }
+    }
+
+    /// Create an inline string, if possible
+    #[inline]
+    #[must_use]
+    pub fn try_inline(other: &str) -> Option<Self> {
+        KStringInner::try_inline(other).map(|inner| Self { inner })
+    }
+}
+
+impl<B: crate::backend::StorageBackend> KString<B> {
     /// Create an owned `KString`.
     #[inline]
     #[must_use]
-    pub fn from_boxed(other: BoxedStr) -> Self {
+    pub fn from_boxed(other: crate::backend::BoxedStr) -> Self {
         Self {
             inner: KStringInner::from_boxed(other),
         }
@@ -53,22 +66,6 @@ impl KString {
         Self {
             inner: KStringInner::from_ref(other),
         }
-    }
-
-    /// Create a reference to a `'static` data.
-    #[inline]
-    #[must_use]
-    pub const fn from_static(other: &'static str) -> Self {
-        Self {
-            inner: KStringInner::from_static(other),
-        }
-    }
-
-    /// Create an inline string, if possible
-    #[inline]
-    #[must_use]
-    pub fn try_inline(other: &str) -> Option<Self> {
-        KStringInner::try_inline(other).map(|inner| Self { inner })
     }
 
     /// Get a reference to the `KString`.
@@ -95,7 +92,7 @@ impl KString {
     /// Convert to a mutable string type, cloning the data if necessary.
     #[inline]
     #[must_use]
-    pub fn into_boxed_str(self) -> BoxedStr {
+    pub fn into_boxed_str(self) -> crate::backend::BoxedStr {
         self.inner.into_boxed_str()
     }
 
@@ -107,7 +104,7 @@ impl KString {
     }
 }
 
-impl std::ops::Deref for KString {
+impl<B: crate::backend::StorageBackend> std::ops::Deref for KString<B> {
     type Target = str;
 
     #[inline]
@@ -116,186 +113,186 @@ impl std::ops::Deref for KString {
     }
 }
 
-impl Eq for KString {}
+impl<B: crate::backend::StorageBackend> Eq for KString<B> {}
 
-impl<'s> PartialEq<KString> for KString {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<KString<B>> for KString<B> {
     #[inline]
-    fn eq(&self, other: &KString) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl<'s> PartialEq<str> for KString {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<str> for KString<B> {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         PartialEq::eq(self.as_str(), other)
     }
 }
 
-impl<'s> PartialEq<&'s str> for KString {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<&'s str> for KString<B> {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
         PartialEq::eq(self.as_str(), *other)
     }
 }
 
-impl<'s> PartialEq<String> for KString {
+impl<'s, B: crate::backend::StorageBackend> PartialEq<String> for KString<B> {
     #[inline]
     fn eq(&self, other: &StdString) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl Ord for KString {
+impl<B: crate::backend::StorageBackend> Ord for KString<B> {
     #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
-impl PartialOrd for KString {
+impl<B: crate::backend::StorageBackend> PartialOrd for KString<B> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.as_str().partial_cmp(other.as_str())
     }
 }
 
-impl std::hash::Hash for KString {
+impl<B: crate::backend::StorageBackend> std::hash::Hash for KString<B> {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
     }
 }
 
-impl fmt::Debug for KString {
+impl<B: crate::backend::StorageBackend> fmt::Debug for KString<B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)
     }
 }
 
-impl fmt::Display for KString {
+impl<B: crate::backend::StorageBackend> fmt::Display for KString<B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
-impl AsRef<str> for KString {
+impl<B: crate::backend::StorageBackend> AsRef<str> for KString<B> {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl AsRef<[u8]> for KString {
+impl<B: crate::backend::StorageBackend> AsRef<[u8]> for KString<B> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl AsRef<std::ffi::OsStr> for KString {
+impl<B: crate::backend::StorageBackend> AsRef<std::ffi::OsStr> for KString<B> {
     #[inline]
     fn as_ref(&self) -> &std::ffi::OsStr {
         (&**self).as_ref()
     }
 }
 
-impl AsRef<std::path::Path> for KString {
+impl<B: crate::backend::StorageBackend> AsRef<std::path::Path> for KString<B> {
     #[inline]
     fn as_ref(&self) -> &std::path::Path {
         std::path::Path::new(self)
     }
 }
 
-impl std::borrow::Borrow<str> for KString {
+impl<B: crate::backend::StorageBackend> std::borrow::Borrow<str> for KString<B> {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
-impl Default for KString {
+impl<B: crate::backend::StorageBackend> Default for KString<B> {
     #[inline]
     fn default() -> Self {
-        Self::from_static("")
+        Self::new()
     }
 }
 
-impl<'s> From<KStringRef<'s>> for KString {
+impl<'s, B: crate::backend::StorageBackend> From<KStringRef<'s>> for KString<B> {
     #[inline]
     fn from(other: KStringRef<'s>) -> Self {
         other.to_owned()
     }
 }
 
-impl<'s> From<&'s KStringRef<'s>> for KString {
+impl<'s, B: crate::backend::StorageBackend> From<&'s KStringRef<'s>> for KString<B> {
     #[inline]
     fn from(other: &'s KStringRef<'s>) -> Self {
         other.to_owned()
     }
 }
 
-impl<'s> From<KStringCow<'s>> for KString {
+impl<'s, B: crate::backend::StorageBackend> From<KStringCow<'s, B>> for KString<B> {
     #[inline]
-    fn from(other: KStringCow<'s>) -> Self {
+    fn from(other: KStringCow<'s, B>) -> Self {
         other.into_owned()
     }
 }
 
-impl<'s> From<&'s KStringCow<'s>> for KString {
+impl<'s, B: crate::backend::StorageBackend> From<&'s KStringCow<'s, B>> for KString<B> {
     #[inline]
-    fn from(other: &'s KStringCow<'s>) -> Self {
+    fn from(other: &'s KStringCow<'s, B>) -> Self {
         other.clone().into_owned()
     }
 }
 
-impl From<StdString> for KString {
+impl<B: crate::backend::StorageBackend> From<StdString> for KString<B> {
     #[inline]
     fn from(other: StdString) -> Self {
         Self::from_string(other)
     }
 }
 
-impl<'s> From<&'s StdString> for KString {
+impl<'s, B: crate::backend::StorageBackend> From<&'s StdString> for KString<B> {
     #[inline]
     fn from(other: &'s StdString) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl From<BoxedStr> for KString {
+impl<B: crate::backend::StorageBackend> From<crate::backend::BoxedStr> for KString<B> {
     #[inline]
-    fn from(other: BoxedStr) -> Self {
+    fn from(other: crate::backend::BoxedStr) -> Self {
         Self::from_boxed(other)
     }
 }
 
-impl<'s> From<&'s BoxedStr> for KString {
+impl<'s, B: crate::backend::StorageBackend> From<&'s crate::backend::BoxedStr> for KString<B> {
     #[inline]
-    fn from(other: &'s BoxedStr) -> Self {
+    fn from(other: &'s crate::backend::BoxedStr) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl From<&'static str> for KString {
+impl<B: crate::backend::StorageBackend> From<&'static str> for KString<B> {
     #[inline]
     fn from(other: &'static str) -> Self {
         Self::from_static(other)
     }
 }
 
-impl std::str::FromStr for KString {
+impl<B: crate::backend::StorageBackend> std::str::FromStr for KString<B> {
     type Err = std::convert::Infallible;
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(KString::from_ref(s))
+        Ok(Self::from_ref(s))
     }
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for KString {
+impl<B: crate::backend::StorageBackend> serde::Serialize for KString<B> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -306,21 +303,21 @@ impl serde::Serialize for KString {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for KString {
+impl<'de, B: crate::backend::StorageBackend> serde::Deserialize<'de> for KString<B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_string(StringVisitor)
+        deserializer.deserialize_string(StringVisitor(std::marker::PhantomData))
     }
 }
 
 #[cfg(feature = "serde")]
-struct StringVisitor;
+struct StringVisitor<B>(std::marker::PhantomData<B>);
 
 #[cfg(feature = "serde")]
-impl<'de> serde::de::Visitor<'de> for StringVisitor {
-    type Value = KString;
+impl<'de, B: crate::backend::StorageBackend> serde::de::Visitor<'de> for StringVisitor<B> {
+    type Value = KString<B>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("a string")
@@ -330,14 +327,14 @@ impl<'de> serde::de::Visitor<'de> for StringVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(KString::from_ref(v))
+        Ok(Self::Value::from_ref(v))
     }
 
     fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        Ok(KString::from_string(v))
+        Ok(Self::Value::from_string(v))
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -345,7 +342,7 @@ impl<'de> serde::de::Visitor<'de> for StringVisitor {
         E: serde::de::Error,
     {
         match std::str::from_utf8(v) {
-            Ok(s) => Ok(KString::from_ref(s)),
+            Ok(s) => Ok(Self::Value::from_ref(s)),
             Err(_) => Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Bytes(v),
                 &self,
@@ -358,7 +355,7 @@ impl<'de> serde::de::Visitor<'de> for StringVisitor {
         E: serde::de::Error,
     {
         match String::from_utf8(v) {
-            Ok(s) => Ok(KString::from_string(s)),
+            Ok(s) => Ok(Self::Value::from_string(s)),
             Err(e) => Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Bytes(&e.into_bytes()),
                 &self,
@@ -373,41 +370,13 @@ use inner::KStringInner;
 mod inner {
     use super::*;
 
-    pub(super) enum KStringInner {
+    pub(super) enum KStringInner<B> {
         Singleton(&'static str),
         Inline(StackString<CAPACITY>),
-        Owned(OwnedStr),
+        Owned(B),
     }
 
-    impl KStringInner {
-        #[inline]
-        pub(super) fn from_boxed(other: BoxedStr) -> Self {
-            #[allow(clippy::useless_conversion)]
-            Self::Owned(OwnedStr::from(other))
-        }
-
-        #[inline]
-        pub(super) fn from_string(other: StdString) -> Self {
-            if (0..=CAPACITY).contains(&other.len()) {
-                let inline = { StackString::new(other.as_str()) };
-                Self::Inline(inline)
-            } else {
-                #[allow(clippy::useless_conversion)]
-                Self::Owned(OwnedStr::from(other.into_boxed_str()))
-            }
-        }
-
-        #[inline]
-        pub(super) fn from_ref(other: &str) -> Self {
-            if (0..=CAPACITY).contains(&other.len()) {
-                let inline = { StackString::new(other) };
-                Self::Inline(inline)
-            } else {
-                #[allow(clippy::useless_conversion)]
-                Self::Owned(OwnedStr::from(other))
-            }
-        }
-
+    impl<B> KStringInner<B> {
         /// Create a reference to a `'static` data.
         #[inline]
         pub const fn from_static(other: &'static str) -> Self {
@@ -417,6 +386,34 @@ mod inner {
         #[inline]
         pub fn try_inline(other: &str) -> Option<Self> {
             StackString::try_new(other).map(Self::Inline)
+        }
+    }
+
+    impl<B: crate::backend::StorageBackend> KStringInner<B> {
+        #[inline]
+        pub(super) fn from_boxed(other: BoxedStr) -> Self {
+            #[allow(clippy::useless_conversion)]
+            Self::Owned(B::from_boxed_str(other))
+        }
+
+        #[inline]
+        pub(super) fn from_string(other: StdString) -> Self {
+            if (0..=CAPACITY).contains(&other.len()) {
+                let inline = { StackString::new(other.as_str()) };
+                Self::Inline(inline)
+            } else {
+                Self::from_boxed(other.into_boxed_str())
+            }
+        }
+
+        #[inline]
+        pub(super) fn from_ref(other: &str) -> Self {
+            if (0..=CAPACITY).contains(&other.len()) {
+                let inline = { StackString::new(other) };
+                Self::Inline(inline)
+            } else {
+                Self::Owned(B::from_str(other))
+            }
         }
 
         #[inline]
@@ -465,7 +462,7 @@ mod inner {
     //
     // My only guess is that the `clone()` calls we delegate to are just that much bigger than
     // `as_str()` that, when combined with a jump table, is blowing the icache, slowing things down.
-    impl Clone for KStringInner {
+    impl<B: crate::backend::StorageBackend> Clone for KStringInner<B> {
         fn clone(&self) -> Self {
             match self {
                 Self::Singleton(s) => Self::Singleton(s),
@@ -489,7 +486,7 @@ mod inner {
     // discriminant.  The question is whether faster len=1-16 "allocations" outweighs going to the heap
     // for len=17-22.
     #[allow(unused)]
-    const ALIGNED_CAPACITY: usize = std::mem::size_of::<crate::string::OwnedStr>() - LEN_SIZE;
+    const ALIGNED_CAPACITY: usize = std::mem::size_of::<crate::backend::DefaultStr>() - LEN_SIZE;
 
     #[cfg(feature = "max_inline")]
     const CAPACITY: usize = MAX_CAPACITY;
@@ -501,18 +498,43 @@ mod inner {
 mod inner {
     use super::*;
 
-    pub(super) union KStringInner {
+    pub(super) union KStringInner<B> {
         tag: TagVariant,
         singleton: SingletonVariant,
-        owned: std::mem::ManuallyDrop<OwnedVariant>,
+        owned: std::mem::ManuallyDrop<OwnedVariant<B>>,
         inline: InlineVariant,
     }
 
-    impl KStringInner {
+    impl<B> KStringInner<B> {
+        /// Create a reference to a `'static` data.
         #[inline]
-        pub(super) fn from_boxed(other: BoxedStr) -> Self {
+        pub const fn from_static(other: &'static str) -> Self {
+            Self {
+                singleton: SingletonVariant::new(other),
+            }
+        }
+
+        #[inline]
+        pub fn try_inline(other: &str) -> Option<Self> {
+            StackString::try_new(other).map(|inline| Self {
+                inline: InlineVariant::new(inline),
+            })
+        }
+
+        #[inline]
+        const fn tag(&self) -> Tag {
+            unsafe {
+                // SAFETY: `tag` is in the same spot in each variant
+                self.tag.tag
+            }
+        }
+    }
+
+    impl<B: crate::backend::StorageBackend> KStringInner<B> {
+        #[inline]
+        pub(super) fn from_boxed(other: crate::backend::BoxedStr) -> Self {
             #[allow(clippy::useless_conversion)]
-            let payload = OwnedStr::from(other);
+            let payload = B::from_boxed_str(other);
             Self {
                 owned: std::mem::ManuallyDrop::new(OwnedVariant::new(payload)),
             }
@@ -545,26 +567,11 @@ mod inner {
                 }
             } else {
                 #[allow(clippy::useless_conversion)]
-                let payload = OwnedStr::from(other);
+                let payload = B::from_str(other);
                 Self {
                     owned: std::mem::ManuallyDrop::new(OwnedVariant::new(payload)),
                 }
             }
-        }
-
-        /// Create a reference to a `'static` data.
-        #[inline]
-        pub const fn from_static(other: &'static str) -> Self {
-            Self {
-                singleton: SingletonVariant::new(other),
-            }
-        }
-
-        #[inline]
-        pub fn try_inline(other: &str) -> Option<Self> {
-            StackString::try_new(other).map(|inline| Self {
-                inline: InlineVariant::new(inline),
-            })
         }
 
         #[inline]
@@ -575,7 +582,7 @@ mod inner {
                 if tag.is_singleton() {
                     KStringRef::from_static(self.singleton.payload)
                 } else if tag.is_owned() {
-                    KStringRef::from_ref(self.owned.payload.as_ref())
+                    KStringRef::from_ref(self.owned.payload.as_str())
                 } else {
                     debug_assert!(tag.is_inline());
                     KStringRef::from_ref(self.inline.payload.as_str())
@@ -591,7 +598,7 @@ mod inner {
                 if tag.is_singleton() {
                     self.singleton.payload
                 } else if tag.is_owned() {
-                    self.owned.payload.as_ref()
+                    self.owned.payload.as_str()
                 } else {
                     debug_assert!(tag.is_inline());
                     self.inline.payload.as_str()
@@ -600,17 +607,17 @@ mod inner {
         }
 
         #[inline]
-        pub(super) fn into_boxed_str(self) -> BoxedStr {
+        pub(super) fn into_boxed_str(self) -> crate::backend::BoxedStr {
             let tag = self.tag();
             unsafe {
                 // SAFETY: `tag` ensures access to correct variant
                 if tag.is_singleton() {
-                    BoxedStr::from(self.singleton.payload)
+                    crate::backend::BoxedStr::from(self.singleton.payload)
                 } else if tag.is_owned() {
-                    BoxedStr::from(self.owned.payload.as_ref())
+                    crate::backend::BoxedStr::from(self.owned.payload.as_str())
                 } else {
                     debug_assert!(tag.is_inline());
-                    BoxedStr::from(self.inline.payload.as_ref())
+                    crate::backend::BoxedStr::from(self.inline.payload.as_ref())
                 }
             }
         }
@@ -624,19 +631,11 @@ mod inner {
                 if tag.is_singleton() {
                     Cow::Borrowed(self.singleton.payload)
                 } else if tag.is_owned() {
-                    Cow::Owned(self.owned.payload.as_ref().into())
+                    Cow::Owned(self.owned.payload.as_str().into())
                 } else {
                     debug_assert!(tag.is_inline());
                     Cow::Owned(self.inline.payload.as_str().into())
                 }
-            }
-        }
-
-        #[inline]
-        fn tag(&self) -> Tag {
-            unsafe {
-                // SAFETY: `tag` is in the same spot in each variant
-                self.tag.tag
             }
         }
     }
@@ -649,7 +648,7 @@ mod inner {
     //
     // My only guess is that the `clone()` calls we delegate to are just that much bigger than
     // `as_str()` that, when combined with a jump table, is blowing the icache, slowing things down.
-    impl Clone for KStringInner {
+    impl<B: Clone> Clone for KStringInner<B> {
         fn clone(&self) -> Self {
             let tag = self.tag();
             if tag.is_owned() {
@@ -671,7 +670,7 @@ mod inner {
         }
     }
 
-    impl Drop for KStringInner {
+    impl<B> Drop for KStringInner<B> {
         fn drop(&mut self) {
             let tag = self.tag();
             if tag.is_owned() {
@@ -690,7 +689,7 @@ mod inner {
     const TAG_SIZE: usize = std::mem::size_of::<Tag>();
 
     #[allow(unused)]
-    const PAYLOAD_SIZE: usize = std::mem::size_of::<crate::string::OwnedStr>();
+    const PAYLOAD_SIZE: usize = std::mem::size_of::<crate::backend::DefaultStr>();
     type Payload = Padding<PAYLOAD_SIZE>;
 
     #[allow(unused)]
@@ -753,17 +752,17 @@ mod inner {
 
     #[derive(Clone)]
     #[repr(C)]
-    struct OwnedVariant {
-        payload: OwnedStr,
+    struct OwnedVariant<B> {
+        payload: B,
         pad: Padding<PAYLOAD_PAD_SIZE>,
         tag: Tag,
     }
-    static_assertions::assert_eq_size!(Payload, std::mem::ManuallyDrop<crate::string::OwnedStr>);
-    static_assertions::assert_eq_size!(Target, OwnedVariant);
+    static_assertions::assert_eq_size!(Payload, crate::backend::DefaultStr);
+    static_assertions::assert_eq_size!(Target, OwnedVariant<crate::backend::DefaultStr>);
 
-    impl OwnedVariant {
+    impl<B> OwnedVariant<B> {
         #[inline]
-        const fn new(payload: OwnedStr) -> Self {
+        const fn new(payload: B) -> Self {
             Self {
                 payload,
                 pad: Padding::new(),
@@ -772,7 +771,7 @@ mod inner {
         }
     }
 
-    impl std::fmt::Debug for OwnedVariant {
+    impl<B: crate::backend::StorageBackend> std::fmt::Debug for OwnedVariant<B> {
         #[inline]
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             self.payload.fmt(f)

--- a/src/string.rs
+++ b/src/string.rs
@@ -394,7 +394,7 @@ mod inner {
 
     impl<B: crate::backend::HeapStr> KStringInner<B> {
         #[inline]
-        pub(super) fn from_boxed(other: BoxedStr) -> Self {
+        pub(super) fn from_boxed(other: crate::backend::BoxedStr) -> Self {
             #[allow(clippy::useless_conversion)]
             Self::Owned(B::from_boxed_str(other))
         }
@@ -424,7 +424,7 @@ mod inner {
             match self {
                 Self::Singleton(s) => KStringRef::from_static(s),
                 Self::Inline(s) => KStringRef::from_ref(s.as_str()),
-                Self::Owned(s) => KStringRef::from_ref(s),
+                Self::Owned(s) => KStringRef::from_ref(s.as_str()),
             }
         }
 
@@ -433,16 +433,16 @@ mod inner {
             match self {
                 Self::Singleton(s) => s,
                 Self::Inline(s) => s.as_str(),
-                Self::Owned(s) => s,
+                Self::Owned(s) => s.as_str(),
             }
         }
 
         #[inline]
-        pub(super) fn into_boxed_str(self) -> BoxedStr {
+        pub(super) fn into_boxed_str(self) -> crate::backend::BoxedStr {
             match self {
-                Self::Singleton(s) => BoxedStr::from(s),
-                Self::Inline(s) => BoxedStr::from(s.as_str()),
-                Self::Owned(s) => BoxedStr::from(s.as_ref()),
+                Self::Singleton(s) => crate::backend::BoxedStr::from(s),
+                Self::Inline(s) => crate::backend::BoxedStr::from(s.as_str()),
+                Self::Owned(s) => crate::backend::BoxedStr::from(s.as_str()),
             }
         }
 
@@ -452,7 +452,7 @@ mod inner {
             match self {
                 Self::Singleton(s) => Cow::Borrowed(s),
                 Self::Inline(s) => Cow::Owned(s.as_str().into()),
-                Self::Owned(s) => Cow::Owned(s.as_ref().into()),
+                Self::Owned(s) => Cow::Owned(s.as_str().into()),
             }
         }
     }
@@ -465,7 +465,7 @@ mod inner {
     //
     // My only guess is that the `clone()` calls we delegate to are just that much bigger than
     // `as_str()` that, when combined with a jump table, is blowing the icache, slowing things down.
-    impl<B: crate::backend::HeapStr> Clone for KStringInner<B> {
+    impl<B: Clone> Clone for KStringInner<B> {
         fn clone(&self) -> Self {
             match self {
                 Self::Singleton(s) => Self::Singleton(s),

--- a/src/string_cow.rs
+++ b/src/string_cow.rs
@@ -41,7 +41,7 @@ impl<'s, B> KStringCowBase<'s, B> {
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> KStringCowBase<'s, B> {
     /// Create an owned `KStringCowBase`.
     #[inline]
     #[must_use]
@@ -112,7 +112,7 @@ impl<'s, B: crate::backend::StorageBackend> KStringCowBase<'s, B> {
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> KStringCowInner<'s, B> {
+impl<'s, B: crate::backend::HeapStr> KStringCowInner<'s, B> {
     #[inline]
     fn as_ref(&self) -> KStringRef<'_> {
         match self {
@@ -155,7 +155,7 @@ impl<'s, B: crate::backend::StorageBackend> KStringCowInner<'s, B> {
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> std::ops::Deref for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> std::ops::Deref for KStringCowBase<'s, B> {
     type Target = str;
 
     #[inline]
@@ -164,102 +164,100 @@ impl<'s, B: crate::backend::StorageBackend> std::ops::Deref for KStringCowBase<'
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> Eq for KStringCowBase<'s, B> {}
+impl<'s, B: crate::backend::HeapStr> Eq for KStringCowBase<'s, B> {}
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<KStringCowBase<'s, B>>
-    for KStringCowBase<'s, B>
-{
+impl<'s, B: crate::backend::HeapStr> PartialEq<KStringCowBase<'s, B>> for KStringCowBase<'s, B> {
     #[inline]
     fn eq(&self, other: &KStringCowBase<'s, B>) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<str> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> PartialEq<str> for KStringCowBase<'s, B> {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         PartialEq::eq(self.as_str(), other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<&'s str> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> PartialEq<&'s str> for KStringCowBase<'s, B> {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
         PartialEq::eq(self.as_str(), *other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialEq<String> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> PartialEq<String> for KStringCowBase<'s, B> {
     #[inline]
     fn eq(&self, other: &StdString) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> Ord for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> Ord for KStringCowBase<'s, B> {
     #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> PartialOrd for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> PartialOrd for KStringCowBase<'s, B> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.as_str().partial_cmp(other.as_str())
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> std::hash::Hash for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> std::hash::Hash for KStringCowBase<'s, B> {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> fmt::Debug for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> fmt::Debug for KStringCowBase<'s, B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> fmt::Display for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> fmt::Display for KStringCowBase<'s, B> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> AsRef<str> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> AsRef<str> for KStringCowBase<'s, B> {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> AsRef<[u8]> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> AsRef<[u8]> for KStringCowBase<'s, B> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> AsRef<std::ffi::OsStr> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> AsRef<std::ffi::OsStr> for KStringCowBase<'s, B> {
     #[inline]
     fn as_ref(&self) -> &std::ffi::OsStr {
         (&**self).as_ref()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> AsRef<std::path::Path> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> AsRef<std::path::Path> for KStringCowBase<'s, B> {
     #[inline]
     fn as_ref(&self) -> &std::path::Path {
         std::path::Path::new(self)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> std::borrow::Borrow<str> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> std::borrow::Borrow<str> for KStringCowBase<'s, B> {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
@@ -273,7 +271,7 @@ impl<'s, B> Default for KStringCowBase<'s, B> {
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<KStringBase<B>> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<KStringBase<B>> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: KStringBase<B>) -> Self {
         let inner = KStringCowInner::Owned(other);
@@ -281,7 +279,7 @@ impl<'s, B: crate::backend::StorageBackend> From<KStringBase<B>> for KStringCowB
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringBase<B>> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s KStringBase<B>> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: &'s KStringBase<B>) -> Self {
         let other = other.as_ref();
@@ -289,7 +287,7 @@ impl<'s, B: crate::backend::StorageBackend> From<&'s KStringBase<B>> for KString
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<KStringRef<'s>> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<KStringRef<'s>> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: KStringRef<'s>) -> Self {
         match other.inner {
@@ -299,7 +297,7 @@ impl<'s, B: crate::backend::StorageBackend> From<KStringRef<'s>> for KStringCowB
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringRef<'s>> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s KStringRef<'s>> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: &'s KStringRef<'s>) -> Self {
         match other.inner {
@@ -309,21 +307,21 @@ impl<'s, B: crate::backend::StorageBackend> From<&'s KStringRef<'s>> for KString
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<StdString> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<StdString> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: StdString) -> Self {
         Self::from_string(other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s StdString> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s StdString> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: &'s StdString) -> Self {
         Self::from_ref(other.as_str())
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<BoxedStr> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<BoxedStr> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: BoxedStr) -> Self {
         // Since the memory is already allocated, don't bother moving it into a FixedString
@@ -331,21 +329,21 @@ impl<'s, B: crate::backend::StorageBackend> From<BoxedStr> for KStringCowBase<'s
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s BoxedStr> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s BoxedStr> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: &'s BoxedStr) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s str> for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> From<&'s str> for KStringCowBase<'s, B> {
     #[inline]
     fn from(other: &'s str) -> Self {
         Self::from_ref(other)
     }
 }
 
-impl<B: crate::backend::StorageBackend> std::str::FromStr for KStringCowBase<'_, B> {
+impl<B: crate::backend::HeapStr> std::str::FromStr for KStringCowBase<'_, B> {
     type Err = std::convert::Infallible;
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -354,7 +352,7 @@ impl<B: crate::backend::StorageBackend> std::str::FromStr for KStringCowBase<'_,
 }
 
 #[cfg(feature = "serde")]
-impl<'s, B: crate::backend::StorageBackend> serde::Serialize for KStringCowBase<'s, B> {
+impl<'s, B: crate::backend::HeapStr> serde::Serialize for KStringCowBase<'s, B> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -365,7 +363,7 @@ impl<'s, B: crate::backend::StorageBackend> serde::Serialize for KStringCowBase<
 }
 
 #[cfg(feature = "serde")]
-impl<'de, 's, B: crate::backend::StorageBackend> serde::Deserialize<'de> for KStringCowBase<'s, B> {
+impl<'de, 's, B: crate::backend::HeapStr> serde::Deserialize<'de> for KStringCowBase<'s, B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use crate::KString;
-use crate::KStringCow;
+use crate::KStringBase;
+use crate::KStringCowBase;
 
 type StdString = std::string::String;
 type BoxedStr = Box<str>;
@@ -20,7 +20,7 @@ pub(crate) enum KStringRefInner<'s> {
 }
 
 impl<'s> KStringRef<'s> {
-    /// Create a new empty `KString`.
+    /// Create a new empty `KStringBase`.
     #[inline]
     #[must_use]
     pub const fn new() -> Self {
@@ -49,7 +49,7 @@ impl<'s> KStringRef<'s> {
     #[inline]
     #[must_use]
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_owned<B: crate::backend::StorageBackend>(&self) -> KString<B> {
+    pub fn to_owned<B: crate::backend::StorageBackend>(&self) -> KStringBase<B> {
         self.inner.to_owned()
     }
 
@@ -71,10 +71,10 @@ impl<'s> KStringRef<'s> {
 impl<'s> KStringRefInner<'s> {
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    fn to_owned<B: crate::backend::StorageBackend>(&self) -> KString<B> {
+    fn to_owned<B: crate::backend::StorageBackend>(&self) -> KStringBase<B> {
         match self {
-            Self::Borrowed(s) => KString::from_ref(s),
-            Self::Singleton(s) => KString::from_static(s),
+            Self::Borrowed(s) => KStringBase::from_ref(s),
+            Self::Singleton(s) => KStringBase::from_static(s),
         }
     }
 
@@ -208,16 +208,16 @@ impl<'s> Default for KStringRef<'s> {
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KString<B>> for KStringRef<'s> {
+impl<'s, B: crate::backend::StorageBackend> From<&'s KStringBase<B>> for KStringRef<'s> {
     #[inline]
-    fn from(other: &'s KString<B>) -> Self {
+    fn from(other: &'s KStringBase<B>) -> Self {
         other.as_ref()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringCow<'s, B>> for KStringRef<'s> {
+impl<'s, B: crate::backend::StorageBackend> From<&'s KStringCowBase<'s, B>> for KStringRef<'s> {
     #[inline]
-    fn from(other: &'s KStringCow<'s, B>) -> Self {
+    fn from(other: &'s KStringCowBase<'s, B>) -> Self {
         other.as_ref()
     }
 }

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -49,7 +49,7 @@ impl<'s> KStringRef<'s> {
     #[inline]
     #[must_use]
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_owned<B: crate::backend::StorageBackend>(&self) -> KStringBase<B> {
+    pub fn to_owned<B: crate::backend::HeapStr>(&self) -> KStringBase<B> {
         self.inner.to_owned()
     }
 
@@ -71,7 +71,7 @@ impl<'s> KStringRef<'s> {
 impl<'s> KStringRefInner<'s> {
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    fn to_owned<B: crate::backend::StorageBackend>(&self) -> KStringBase<B> {
+    fn to_owned<B: crate::backend::HeapStr>(&self) -> KStringBase<B> {
         match self {
             Self::Borrowed(s) => KStringBase::from_ref(s),
             Self::Singleton(s) => KStringBase::from_static(s),
@@ -208,14 +208,14 @@ impl<'s> Default for KStringRef<'s> {
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringBase<B>> for KStringRef<'s> {
+impl<'s, B: crate::backend::HeapStr> From<&'s KStringBase<B>> for KStringRef<'s> {
     #[inline]
     fn from(other: &'s KStringBase<B>) -> Self {
         other.as_ref()
     }
 }
 
-impl<'s, B: crate::backend::StorageBackend> From<&'s KStringCowBase<'s, B>> for KStringRef<'s> {
+impl<'s, B: crate::backend::HeapStr> From<&'s KStringCowBase<'s, B>> for KStringRef<'s> {
     #[inline]
     fn from(other: &'s KStringCowBase<'s, B>) -> Self {
         other.as_ref()


### PR DESCRIPTION
I chose type aliases for defaults rather than defaulted type parameters because the latter is less friendly for type inference.  There is no short form; you have to do `KString::<kstring::backend::BoxedStr>::EMPTY`.