### PR TITLE
fix: Ensure we forbid unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! # Feature Flags
 //!
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
-#![cfg_attr(feature = "safe", forbid(unsafe_code))]
+#![cfg_attr(not(feature = "unsafe"), forbid(unsafe_code))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Found via rust-lang/cargo#10554

- [x] Tests created for any new feature or regression tests for bugfixes.
