### PR TITLE
Force tag to the same position in KStringInner

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -501,6 +501,7 @@ mod inner {
 mod inner {
     use super::*;
 
+    #[repr(C)]
     pub(super) union KStringInner<B> {
         tag: TagVariant,
         singleton: SingletonVariant,


### PR DESCRIPTION
`tag()` relies on `KStringInner` having a tag field at the same offset in every union variant, and every union variant is `repr(C)` so that this holds (provided that `B` has the same size, anyway -- since it's a sealed trait, that is guaranteed for any constructed instance, though it's a bit subtle).

However, the union _itself_ does not have a guaranteed layout unless one uses `repr(C)`. It's a bit silly, but technically every single variant could be in a different location, causing the tags not to line up within the union even though they do within the structs individually. See e.g. https://rust-lang.github.io/unsafe-code-guidelines/layout/unions.html

The fixes would be:

1. use a struct with a tag field first, and then a union field second. (Or even an enum, as is done with the non-`unsafe` implementation).
2. use a repr(C) union instead of a repr(Rust) union.
3. Maybe add some assertions so that even with repr(Rust), the layout is as expected?

I opted to do (2) as a quick fix to send out.

(Did not add tests, because I believe this has no change in behavior -- the layout is presumably the same now as it was before, only now it is _guaranteed_.)